### PR TITLE
Fix kube config

### DIFF
--- a/Dockerfile-canary
+++ b/Dockerfile-canary
@@ -49,7 +49,7 @@ RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
 
 COPY files/etc/ansible/* /etc/ansible/
 COPY files/usr/bin/* /usr/bin/
-COPY files/opt/apb/* /opt/apb/
+COPY files/opt/apb/.kube/config /opt/apb/.kube/config
 
 RUN mkdir -p /usr/share/ansible/openshift \
               /etc/ansible /opt/ansible \

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -19,8 +19,4 @@ RUN mkdir -p /usr/share/ansible/openshift \
              && chown -R ${USER_NAME}:0 /opt/{ansible,apb} \
              && chmod -R g=u /opt/{ansible,apb} /etc/passwd
 
-COPY files/etc/ansible/* /etc/ansible/
-COPY files/usr/bin/* /usr/bin/
-COPY files/opt/apb/* /opt/apb/
-
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
The `files/opt/apb/.kube/config` file was being copied to `/opt/apb/config`...that will not work. This change puts the kubeconfig where it belongs (in `/opt/apb/.kube/config`) and removes the `COPY` statements from the nightly dockerfile since we just installed `apb-base-scripts`.

Proof the new one works:

```
$ docker run -it --rm --privileged --net=host --entrypoint /bin/cat docker.io/djzager/apb-base:new /opt/apb/.kube/config
apiVersion: v1
clusters:
- cluster:
    certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
    server: https://kubernetes.default:443
  name: kubernetes
contexts:
- context:
    cluster: kubernetes
    user: apb-user
  name: /kubernetes/apb-user
current-context: /kubernetes/apb-user
kind: Config
preferences: {}
users:
- name: apb-user
  user:
    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
```

Proof the old one was broken:
```
$ docker run -it --rm --privileged --net=host --entrypoint /bin/cat docker.io/djzager/apb-base:old /opt/apb/.kube/config
/bin/cat: /opt/apb/.kube/config: No such file or directory
```

Proof that nightly works after removing the `COPY` statements:
```
$ docker run -it --rm --privileged --net=host --entrypoint /bin/cat docker.io/djzager/apb-base:nightly /opt/apb/.kube/config
apiVersion: v1
clusters:
- cluster:
    certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
    server: https://kubernetes.default:443
  name: kubernetes
contexts:
- context:
    cluster: kubernetes
    user: apb-user
  name: /kubernetes/apb-user
current-context: /kubernetes/apb-user
kind: Config
preferences: {}
users:
- name: apb-user
  user:
    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
  
# Just checking permissions.  
$ docker run -it --rm --privileged --net=host --entrypoint /bin/bash docker.io/djzager/apb-base:nightly
bash-4.2# ls -lhat /opt/apb/.kube
total 12K
drwxrwxr-x. 1 apb root 4.0K Dec 19 13:58 ..
drwxrwxr-x. 1 apb root 4.0K Dec 19 13:58 .
-rwxrwxr-x. 1 apb root  437 Dec 15 15:40 config
bash-4.2#
```