### PR TITLE
Bug 1565790 - Prevents ansible from trying to create retry files, which can't be used anyway

### DIFF
--- a/files/etc/ansible/ansible.cfg
+++ b/files/etc/ansible/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
+retry_files_enabled = False
 roles_path = /etc/ansible/roles:/opt/ansible/roles


### PR DESCRIPTION
This gets rid of these confusing/misleading log messages when an APB fails:

  "[WARNING]: Could not create retry file '/opt/apb/actions/deprovision.retry'."
  "[Errno 13] Permission denied: u'/opt/apb/actions/deprovision.retry'"