### PR TITLE
Bug 1533425 - return error when no action found

### DIFF
--- a/files/usr/bin/entrypoint.sh
+++ b/files/usr/bin/entrypoint.sh
@@ -58,7 +58,7 @@ elif [[ -e "$playbooks/$ACTION.yml" ]]; then
   ANSIBLE_ROLES_PATH=/etc/ansible/roles:/opt/ansible/roles ansible-playbook $playbooks/$ACTION.yml  "${@}" ${extra_args}
 else
   echo "'$ACTION' NOT IMPLEMENTED" # TODO
-  exit 0
+  exit 8 # action not found
 fi
 
 EXIT_CODE=$?


### PR DESCRIPTION
When an action that is not supported by the APB is passed in we should return an error code to indicate that the action failed. I've chosen to return 8 which is 1000 in binary. It also seems to be non-standard and hopefully won't conflict with an error code an ansible-playbook would return.