### PR TITLE
Add k8s inventory plugin for usage as conductor container

### DIFF
--- a/Dockerfile-canary
+++ b/Dockerfile-canary
@@ -42,12 +42,8 @@ RUN git clone https://github.com/ansible/ansible-kubernetes-modules.git /etc/ans
 
 RUN git clone https://github.com/ansibleplaybookbundle/ansible-asb-modules.git /etc/ansible/roles/ansibleplaybookbundle.asb-modules
 
-RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
-    && echo '[defaults]' > /etc/ansible/ansible.cfg \
-    && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
-    && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
-
 COPY files/etc/ansible/* /etc/ansible/
+RUN echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
 COPY files/usr/bin/* /usr/bin/
 COPY files/opt/apb/.kube/config /opt/apb/.kube/config
 

--- a/apb-base-scripts.spec
+++ b/apb-base-scripts.spec
@@ -4,14 +4,14 @@
 %define build_timestamp %{nil}
 %endif
 
-Name: apb-base-scripts
-Version:	1.1.5
-Release:	1%{build_timestamp}%{?dist}
-Summary:	Scripts for the apb-base container image
+Name:       apb-base-scripts
+Version:    1.1.5
+Release:    1%{build_timestamp}%{?dist}
+Summary:    Scripts for the apb-base container image
 
-License:	ASL 2.0
-URL:		https://github.com/fusor/apb-examples
-Source0:	https://github.com/fusor/apb-examples/archive/%{name}-%{version}.tar.gz
+License:    ASL 2.0
+URL:        https://github.com/ansibleplaybookbundle/apb-base
+Source0:    https://github.com/ansibleplaybookbundle/apb-base/archive/%{name}-%{version}.tar.gz
 BuildArch:  noarch
 
 %description
@@ -28,6 +28,9 @@ install -m 755 files/usr/bin/test-retrieval-init %{buildroot}%{_bindir}
 install -m 755 files/usr/bin/test-retrieval %{buildroot}%{_bindir}
 install -m 755 files/usr/bin/entrypoint.sh %{buildroot}%{_bindir}
 install -m 755 files/opt/apb/.kube/config %{buildroot}/opt/apb/.kube/config
+install -m 755 files/etc/ansible/ansible.cfg %{buildroot}/etc/ansible/ansible.cfg
+install -m 755 files/etc/ansible/hosts %{buildroot}/etc/ansible/hosts
+install -m 755 files/etc/ansible/k8s.yml %{buildroot}/etc/ansible/k8s.yml
 
 %files
 %doc
@@ -36,6 +39,9 @@ install -m 755 files/opt/apb/.kube/config %{buildroot}/opt/apb/.kube/config
 %{_bindir}/entrypoint.sh
 %dir %{_sysconfdir}/apb-secrets
 /opt/apb/.kube/config
+%{_sysconfdir}/ansible/ansible.cfg
+%{_sysconfdir}/ansible/hosts
+%{_sysconfdir}/ansible/k8s.yml
 
 %changelog
 * Fri Feb 02 2018 David Zager <david.j.zager@gmail.com> 1.1.5-1
@@ -81,4 +87,3 @@ install -m 755 files/opt/apb/.kube/config %{buildroot}/opt/apb/.kube/config
 
 * Fri Aug 18 2017 Jason Montleon <jmontleo@redhat.com> 1.0.1-1
 - new package built with tito
-

--- a/files/etc/ansible/ansible.cfg
+++ b/files/etc/ansible/ansible.cfg
@@ -1,2 +1,6 @@
+[inventory]
+enable_plugins = k8s
+
 [defaults]
 roles_path = /etc/ansible/roles:/opt/ansible/roles
+inventory = /etc/ansible/hosts:/etc/ansible/k8s.yml

--- a/files/etc/ansible/k8s.yml
+++ b/files/etc/ansible/k8s.yml
@@ -1,0 +1,4 @@
+plugin: k8s
+connections:
+    namespaces:
+    - {{ namespace }}


### PR DESCRIPTION
Adds the ability to gather a dynamic inventory of pods in the target namespace on the base container.
This can then be used in conjunction with the kubectl connection plugin to connect to created containers from the APB container and execute e.g. container-enabled Ansible roles for runtime init/config in each container. 

Fixes #16 