### PR TITLE
Bug 1565241 - stops using bash "-x" unless in debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# apb-base
+
+This is a base image that can be used to create an [Ansible Playbook
+Bundle](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle).
+
+## Debug
+
+To turn on debug mode, set the environment variable `BUNDLE_DEBUG=true`. This
+may be easiest to do in the Dockerfile for your APB.
+
+```
+ENV BUNDLE_DEBUG=true
+```
+
+Currently this behavior sets `-x` for the entrypoint, which the bash
+documentation explains will "Print commands and their arguments as they are
+executed". 

--- a/files/usr/bin/entrypoint.sh
+++ b/files/usr/bin/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -x
+if [[ $BUNDLE_DEBUG == "true" ]]; then
+    set -x
+fi
 
 # Work-Around
 # The OpenShift's s2i (source to image) requires that no ENTRYPOINT exist
@@ -33,8 +35,6 @@ if ! whoami &> /dev/null; then
   fi
 fi
 
-set +x
-
 SECRETS_DIR=/etc/apb-secrets
 mounted_secrets=$(ls $SECRETS_DIR)
 
@@ -50,7 +50,6 @@ if [[ ! -z "$mounted_secrets" ]] ; then
     done
     extra_args='--extra-vars no_log=true --extra-vars @/tmp/secrets'
 fi
-set -x
 
 if [[ -e "$playbooks/$ACTION.yaml" ]]; then
   ANSIBLE_ROLES_PATH=/etc/ansible/roles:/opt/ansible/roles ansible-playbook $playbooks/$ACTION.yaml "${@}" ${extra_args}
@@ -63,9 +62,9 @@ fi
 
 EXIT_CODE=$?
 
-set +ex
+set +e
 rm -f /tmp/secrets
-set -ex
+set -e
 
 if [ -f $TEST_RESULT ]; then
    test-retrieval-init


### PR DESCRIPTION
The entrypoint formerly used "-x" in all cases, which would cause all
user-provided parameters to be logged in plaintext. This could include
sensitive data such as passwords.

Because "-x" is useful for debugging while doing APB development, this change
introduces a new way to enable "-x" by setting an environment variable.