### PR TITLE
remove file glob and replace with proper Dockerfile syntax

### DIFF
--- a/Dockerfile-canary
+++ b/Dockerfile-canary
@@ -49,8 +49,7 @@ RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
 
 COPY files/usr/bin/* /usr/bin/
-COPY files/opt/apb/* /opt/apb/
-COPY files/opt/apb/.kube /opt/apb/.kube
+COPY files/opt/apb/. /opt/apb/
 
 RUN mkdir -p /usr/share/ansible/openshift \
               /etc/ansible /opt/ansible \


### PR DESCRIPTION
Replace the file glob in this copy command.

Per https://github.com/moby/moby/issues/15858 if we have 
```
apb-base/opt/apb/.kube/config
apb-base/opt/apb/ansible.cfg
apb-base/opt/apb/hosts
```

`COPY opt/apb/* /opt/apb` will leave us with 
```
/opt/apb/config
/opt/apb/ansible.cfg
/opt/apb/hosts
```
`COPY opt/apb/. /opt/apb` on the otherhand will preserve the directory structure. Leaving us with what you want:
```
/opt/apb/.kube/config
/opt/apb/ansible.cfg
/opt/apb/hosts
```