### PR TITLE
Hardcode the inventory to /etc/ansible/hosts

### DIFF
--- a/files/usr/bin/entrypoint.sh
+++ b/files/usr/bin/entrypoint.sh
@@ -52,9 +52,9 @@ if [[ ! -z "$mounted_secrets" ]] ; then
 fi
 
 if [[ -e "$playbooks/$ACTION.yaml" ]]; then
-  ANSIBLE_ROLES_PATH=/etc/ansible/roles:/opt/ansible/roles ansible-playbook $playbooks/$ACTION.yaml "${@}" ${extra_args}
+  ANSIBLE_ROLES_PATH=/etc/ansible/roles:/opt/ansible/roles ansible-playbook -i /etc/ansible/hosts $playbooks/$ACTION.yaml "${@}" ${extra_args}
 elif [[ -e "$playbooks/$ACTION.yml" ]]; then
-  ANSIBLE_ROLES_PATH=/etc/ansible/roles:/opt/ansible/roles ansible-playbook $playbooks/$ACTION.yml  "${@}" ${extra_args}
+  ANSIBLE_ROLES_PATH=/etc/ansible/roles:/opt/ansible/roles ansible-playbook -i /etc/ansible/hosts $playbooks/$ACTION.yml  "${@}" ${extra_args}
 else
   echo "'$ACTION' NOT IMPLEMENTED" # TODO
   exit 8 # action not found


### PR DESCRIPTION
Make sure the the inventory used in every apb is /etc/ansible/hosts so any apb can come along and change the file to fit the inventory their playbook needs.

```bash
[masters]
localhost ansible_connection=local

[nodes]
localhost ansible_connection=local
```