### PR TITLE
Add multi-line support to entrypoint.sh

### DIFF
--- a/files/usr/bin/entrypoint.sh
+++ b/files/usr/bin/entrypoint.sh
@@ -45,7 +45,13 @@ if [[ ! -z "$mounted_secrets" ]] ; then
 
     for key in ${mounted_secrets} ; do
       for file in $(ls ${SECRETS_DIR}/${key}/..data); do
-        echo "$file: $(cat ${SECRETS_DIR}/${key}/..data/${file})" >> /tmp/secrets
+        lines=$(< ${SECRETS_DIR}/${key}/..data/${file} wc -l)
+        if [ ${lines} -gt 0 ]; then
+          echo "$file: |" >> /tmp/secrets
+          echo "$(cat ${SECRETS_DIR}/${key}/..data/${file} | sed 's/^/  /')" >> /tmp/secrets
+        else
+          echo "$file: $(cat ${SECRETS_DIR}/${key}/..data/${file})" >> /tmp/secrets
+        fi
       done
     done
     extra_args='--extra-vars no_log=true --extra-vars @/tmp/secrets'


### PR DESCRIPTION
This PR adds some specific multi-line secret support to the release-1.2 branch by using wc to detect when a secret is multi-line and adding the expected | before adding the secret contents.

/usr/bin/wc from bin-utils
/usr/bin/sed from sed

The same (or similar) fix may work in the 1.3 or master branches to replace the following:
https://github.com/ansibleplaybookbundle/apb-base/blob/6064ac48320392ebe93db7a31d49de526bfc2d18/files/usr/bin/entrypoint.sh#L65

However, I haven't done any testing on those branches.  