### PR TITLE
Bug 1793336: use nss_wrapper method to update passwd

### DIFF
--- a/apb-base-scripts.spec
+++ b/apb-base-scripts.spec
@@ -14,6 +14,8 @@ URL:		https://github.com/fusor/apb-examples
 Source0:	https://github.com/fusor/apb-examples/archive/%{name}-%{version}.tar.gz
 BuildArch:  noarch
 
+Requires: nss_wrapper
+
 %description
 %{summary}
 

--- a/files/usr/bin/entrypoint.sh
+++ b/files/usr/bin/entrypoint.sh
@@ -29,6 +29,23 @@ if ! whoami &> /dev/null; then
     fi
 fi
 
+USER_ID=$(id -u)
+
+if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
+    NSS_WRAPPER_PASSWD=/tmp/passwd.nss_wrapper
+    NSS_WRAPPER_GROUP=/etc/group
+
+    cp /etc/passwd $NSS_WRAPPER_PASSWD
+
+    echo "${USER_NAME:-apb}:x:$(id -u):0:${USER_NAME:-apb} user:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
+
+    export NSS_WRAPPER_PASSWD
+    export NSS_WRAPPER_GROUP
+
+    LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+    export LD_PRELOAD
+fi
+
 ACTION=$1
 shift
 PLAYBOOKS="/opt/apb/project"


### PR DESCRIPTION
/etc/passwd is not writable. This was one of the proposed options to fix
the problem. It requires nss_wrapper.

Source: http://blog.dscpl.com.au/2015/12/unknown-user-when-running-docker.html